### PR TITLE
✨  feat : 체험 프로그램 등록 페이지 카카오 우편번호 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import CreateProgram from "./pages/Program/CreateProgram";
 
 const Home = () => {
   return <h1>Hello, Local Life!</h1>;
@@ -10,6 +11,7 @@ const App: React.FC = () => {
     <Router>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/program/create" element={<CreateProgram />} />
       </Routes>
     </Router>
   );

--- a/src/pages/Program/CreateProgram.styled.ts
+++ b/src/pages/Program/CreateProgram.styled.ts
@@ -1,0 +1,67 @@
+// src/pages/Program/CreateProgram.styled.ts
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: 'Pretendard', sans-serif;
+`;
+
+export const Title = styled.h1`
+  font-size: 2rem;
+  text-align: center;
+  margin-bottom: 2rem;
+`;
+
+export const AddressSection = styled.div`
+  margin-bottom: 2rem;
+`;
+
+export const Button = styled.button`
+  background-color: #7D11FF;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+
+  &:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+  }
+`;
+
+export const SelectedAddress = styled.div`
+  margin-top: 1rem;
+  padding: 1rem;
+  background-color: #f9f9f9;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+`;
+
+export const DetailInput = styled.input`
+  margin-top: 1rem;
+  padding: 0.5rem;
+  width: 100%;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+`;
+
+export const SubmitSection = styled.div`
+  text-align: center;
+`;
+
+export const FinalAddress = styled.p`
+  margin-top: 1rem;
+  font-weight: bold;
+  font-size: 1rem;
+`;
+
+export const PreviewTitle = styled.h3`
+  margin-top: 1.5rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+`;

--- a/src/pages/Program/CreateProgram.tsx
+++ b/src/pages/Program/CreateProgram.tsx
@@ -1,0 +1,115 @@
+// src/pages/Program/CreateProgram.tsx
+import React, { useState } from 'react';
+import DaumPostcodeModal from './DaumPostcodeModal';
+import * as S from './CreateProgram.styled';
+
+interface AddressData {
+  roadAddress: string;
+  jibunAddress: string;
+  zonecode: string;
+}
+
+const CreateProgram: React.FC = () => {
+  const [isPostcodeModalOpen, setIsPostcodeModalOpen] = useState(false);
+  const [selectedAddress, setSelectedAddress] = useState<AddressData | null>(null);
+  const [detailAddress, setDetailAddress] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleAddressSearch = () => {
+    setIsPostcodeModalOpen(true);
+  };
+
+  const handleAddressComplete = (addressData: AddressData) => {
+    setSelectedAddress(addressData);
+    setIsPostcodeModalOpen(false);
+  };
+
+  const handleCloseModal = () => {
+    setIsPostcodeModalOpen(false);
+  };
+
+  const formatAddress = (addressData: AddressData, detail: string) => {
+    const { roadAddress, jibunAddress, zonecode } = addressData;
+    return `${roadAddress} (${jibunAddress}), ${detail} [${zonecode}]`;
+  };
+
+  const handleSubmit = async () => {
+    if (!selectedAddress || !detailAddress.trim()) {
+      alert('주소를 선택하고 상세주소를 입력해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const fullAddress = formatAddress(selectedAddress, detailAddress);
+
+      const formData = new FormData();
+      formData.append('location', fullAddress);
+
+      const response = await fetch('/programs', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (response.ok) {
+        alert('프로그램이 성공적으로 생성되었습니다.');
+        setSelectedAddress(null);
+        setDetailAddress('');
+      } else {
+        throw new Error('프로그램 생성에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('Error creating program:', error);
+      alert('프로그램 생성 중 오류가 발생했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+      <S.Container>
+        <S.Title>프로그램 생성</S.Title>
+
+        <S.AddressSection>
+          <S.Button type="button" onClick={handleAddressSearch}>
+            주소 검색
+          </S.Button>
+
+          {selectedAddress && (
+              <S.SelectedAddress>
+                <S.DetailInput
+                    type="text"
+                    required
+                    value={detailAddress}
+                    onChange={(e) => setDetailAddress(e.target.value)}
+                    placeholder="상세주소를 입력하세요"
+                />
+
+                <S.PreviewTitle>최종 주소</S.PreviewTitle>
+                <S.FinalAddress>
+                  {formatAddress(selectedAddress, detailAddress || '상세주소')}
+                </S.FinalAddress>
+              </S.SelectedAddress>
+          )}
+        </S.AddressSection>
+
+        <S.SubmitSection>
+          <S.Button
+              onClick={handleSubmit}
+              disabled={!selectedAddress || !detailAddress.trim() || isSubmitting}
+          >
+            {isSubmitting ? '생성 중...' : '프로그램 생성'}
+          </S.Button>
+        </S.SubmitSection>
+
+        <DaumPostcodeModal
+            isOpen={isPostcodeModalOpen}
+            onClose={handleCloseModal}
+            onComplete={handleAddressComplete}
+        />
+      </S.Container>
+  );
+};
+
+export default CreateProgram;

--- a/src/pages/Program/DaumPostcodeModal.styled.ts
+++ b/src/pages/Program/DaumPostcodeModal.styled.ts
@@ -1,0 +1,46 @@
+// src/pages/Program/DaumPostcodeModal.styled.ts
+import styled from 'styled-components';
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+`;
+
+export const ModalSection = styled.section`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 90%;
+  max-width: 500px;
+  height: 600px;
+  background: #fff;
+  transform: translate(-50%, -50%);
+  z-index: 1000;
+  padding: 1rem;
+  box-sizing: border-box;
+
+  @media (max-width: 375px) {
+    width: 95%;
+    height: 90%;
+  }
+`;
+
+export const CloseButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+`;
+
+export const PostcodeContainer = styled.div`
+  width: 100%;
+  height: 100%;
+`;

--- a/src/pages/Program/DaumPostcodeModal.tsx
+++ b/src/pages/Program/DaumPostcodeModal.tsx
@@ -1,0 +1,76 @@
+// src/pages/Program/DaumPostcodeModal.tsx
+import React, { useEffect } from 'react';
+import * as S from './DaumPostcodeModal.styled';
+
+interface DaumPostcodeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onComplete: (addressData: {
+    roadAddress: string;
+    jibunAddress: string;
+    zonecode: string;
+  }) => void;
+}
+
+declare global {
+  interface Window {
+    daum: any;
+  }
+}
+
+const DaumPostcodeModal: React.FC<DaumPostcodeModalProps> = ({
+                                                               isOpen,
+                                                               onClose,
+                                                               onComplete,
+                                                             }) => {
+  useEffect(() => {
+    if (isOpen) {
+      loadDaumPostcodeScript();
+    }
+  }, [isOpen]);
+
+  const loadDaumPostcodeScript = () => {
+    if (window.daum) {
+      openDaumPostcode();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+    script.onload = () => {
+      openDaumPostcode();
+    };
+    document.head.appendChild(script);
+  };
+
+  const openDaumPostcode = () => {
+    new window.daum.Postcode({
+      oncomplete: (data: any) => {
+        onComplete({
+          roadAddress: data.roadAddress,
+          jibunAddress: data.jibunAddress,
+          zonecode: data.zonecode,
+        });
+        onClose();
+      },
+      onclose: () => {
+        onClose();
+      },
+      width: '100%',
+      height: '100%',
+    }).embed(document.getElementById('postcode-container'));
+  };
+
+  if (!isOpen) return null;
+
+  return (
+      <S.Overlay>
+        <S.ModalSection>
+          <S.CloseButton onClick={onClose}>닫기</S.CloseButton>
+          <S.PostcodeContainer id="postcode-container" />
+        </S.ModalSection>
+      </S.Overlay>
+  );
+};
+
+export default DaumPostcodeModal;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -1,7 +1,28 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
+  @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css');
   
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+  
+  body {
+    font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  
+  button {
+    font-family: inherit;
+  }
+  
+  input {
+    font-family: inherit;
+  }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
- DaumPostcodeModal 생성, 카카오 우편번호 API를 embed 방식으로 연동
- CreateProgram.tsx 페이지에서 주소 검색, 상세주소 입력, 최종 주소 병합 기능 구현
- 주소 형식: '[도로명 (지번), 상세주소 [우편번호]]' 로 통일
  - 도로명만 클릭시 도로명 주소만 입력
- 상세주소 미입력 시 제출 불가하도록 유효성 검사 적용
- styled-components를 분리하여 CreateProgram.styled.ts, DaumPostcodeModal.styled.ts 생성
- API 요청 시 multipart/form-data 포맷 사용 (추후 이미지 업로드 대비)
- GlobalStyle로 pretendard 글꼴 임시 설정 
